### PR TITLE
Add description of `øD` to elements.json

### DIFF
--- a/src/data/elements.json
+++ b/src/data/elements.json
@@ -58,5 +58,15 @@
     "tags": ["array"],
     "tagline": "Reverse a list.",
     "description": ""
+  },
+  {
+    "symbol": "øD",
+    "id": "null-dict-compress",
+    "name": "dict-compress",
+    "arity": 1,
+    "keywords": ["dictionary", "compress"],
+    "tags": ["compression", "string"],
+    "tagline": "Dictionary compression",
+    "description": "Optimally compress a string of English using words from the Vyxal dictionary."
   }
 ]


### PR DESCRIPTION
I'm not sure if this is the way to go about it but because of [this issue](https://github.com/Vyxal/vyxapedia/issues/3), I'm adding a description of the dictionary compression element.